### PR TITLE
OCaml-CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
   alpine_3_12:
     runs-on: ubuntu-latest
     container:
-      image: ocaml/opam@sha256:8b2b0b0680a6a3967adc85eb9b35fa1c2053ffe61fedc693a86e40e985945249
+      image: ocaml/opam@sha256:04e3391376e43ecf644ed9919dc5bf1a23fddc078f6f2327140af19cc54e5f1f
       env:
         HOME: /home/opam
       options: --user 1000
@@ -189,7 +189,7 @@ jobs:
   centos_8:
     runs-on: ubuntu-latest
     container:
-      image: ocaml/opam@sha256:1cdf24f875d20d0367cb7c8282487470c7728265224002a339cdbe4440fe8a60
+      image: ocaml/opam@sha256:1f150cd450fd1b63819e336d41c7d8077e04b588cca9ad4b7d34bc24b3908b7b
       env:
         HOME: /home/opam
       options: --user 1000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
-name: Tests for opam-github-workflow and github-workflow
+name: OCaml-CI
 on: [push, pull_request]
 jobs:
-  test:
+  macos_and_windows:
     strategy:
       matrix:
-        operating-system: [macos-latest, ubuntu-latest, windows-latest]
-        ocaml-version: [4.11.0, 4.10.0, 4.09.1]
+        operating-system: [macos-latest, windows-latest]
+        ocaml-version: [4.11.1]
     runs-on: ${{ matrix.operating-system }}
     steps:
     - uses: actions/checkout@v2
@@ -25,3 +25,234 @@ jobs:
       run: opam exec -- dune install
     - name: Testing
       run: opam exec -- dune runtest
+  debian_10_buster:
+    runs-on: ubuntu-latest
+    container:
+      image: ocaml/opam@sha256:3f9ad867a6fded20e9b0db6f23037d010a17c6fd72735689acfb6113f49f8163
+      env:
+        HOME: /home/opam
+      options: --user 1000
+    env:
+      HOME: /home/opam
+    defaults:
+      run:
+        working-directory: /home/opam
+    steps:
+    - run: cd ~/opam-repository && (git cat-file -e bf94421703ae6d95113e5b24890f304701e47b78
+        || git fetch origin master) && git reset -q --hard bf94421703ae6d95113e5b24890f304701e47b78
+        && git log --no-decorate -n1 --oneline && opam update -u
+    - run: mkdir -p /home/opam/package
+    - name: Cloning
+      run: git clone https://github.com/$GITHUB_REPOSITORY . && git checkout $GITHUB_SHA
+      working-directory: /home/opam/package
+    - name: Pinning Packages
+      run: opam pin add -yn opam-github-workflow.dev './' && opam pin add -yn github-workflow.dev
+        './'
+      working-directory: /home/opam/package
+    - name: Installing external dependencies
+      run: opam depext -yt opam-github-workflow.dev github-workflow.dev
+      working-directory: /home/opam/package
+    - name: Installing dependencies
+      run: opam install -t -y . --deps-only
+      working-directory: /home/opam/package
+    - name: Building, installing & testing
+      run: opam exec -- dune build @install @runtest
+      working-directory: /home/opam/package
+  alpine_3_12:
+    runs-on: ubuntu-latest
+    container:
+      image: ocaml/opam@sha256:8b2b0b0680a6a3967adc85eb9b35fa1c2053ffe61fedc693a86e40e985945249
+      env:
+        HOME: /home/opam
+      options: --user 1000
+    env:
+      HOME: /home/opam
+    defaults:
+      run:
+        working-directory: /home/opam
+    steps:
+    - run: cd ~/opam-repository && (git cat-file -e bf94421703ae6d95113e5b24890f304701e47b78
+        || git fetch origin master) && git reset -q --hard bf94421703ae6d95113e5b24890f304701e47b78
+        && git log --no-decorate -n1 --oneline && opam update -u
+    - run: mkdir -p /home/opam/package
+    - name: Cloning
+      run: git clone https://github.com/$GITHUB_REPOSITORY . && git checkout $GITHUB_SHA
+      working-directory: /home/opam/package
+    - name: Pinning Packages
+      run: opam pin add -yn opam-github-workflow.dev './' && opam pin add -yn github-workflow.dev
+        './'
+      working-directory: /home/opam/package
+    - name: Installing external dependencies
+      run: opam depext -yt opam-github-workflow.dev github-workflow.dev
+      working-directory: /home/opam/package
+    - name: Installing dependencies
+      run: opam install -t -y . --deps-only
+      working-directory: /home/opam/package
+    - name: Building, installing & testing
+      run: opam exec -- dune build @install @runtest
+      working-directory: /home/opam/package
+  ubuntu_20_04:
+    runs-on: ubuntu-latest
+    container:
+      image: ocaml/opam@sha256:e907a882879515e0950cb71af419b7bc0594902041783fa2cfdd6282a81195b1
+      env:
+        HOME: /home/opam
+      options: --user 1000
+    env:
+      HOME: /home/opam
+    defaults:
+      run:
+        working-directory: /home/opam
+    steps:
+    - run: cd ~/opam-repository && (git cat-file -e bf94421703ae6d95113e5b24890f304701e47b78
+        || git fetch origin master) && git reset -q --hard bf94421703ae6d95113e5b24890f304701e47b78
+        && git log --no-decorate -n1 --oneline && opam update -u
+    - run: mkdir -p /home/opam/package
+    - name: Cloning
+      run: git clone https://github.com/$GITHUB_REPOSITORY . && git checkout $GITHUB_SHA
+      working-directory: /home/opam/package
+    - name: Pinning Packages
+      run: opam pin add -yn opam-github-workflow.dev './' && opam pin add -yn github-workflow.dev
+        './'
+      working-directory: /home/opam/package
+    - name: Installing external dependencies
+      run: opam depext -yt opam-github-workflow.dev github-workflow.dev
+      working-directory: /home/opam/package
+    - name: Installing dependencies
+      run: opam install -t -y . --deps-only
+      working-directory: /home/opam/package
+    - name: Building, installing & testing
+      run: opam exec -- dune build @install @runtest
+      working-directory: /home/opam/package
+  ubuntu_18_04:
+    runs-on: ubuntu-latest
+    container:
+      image: ocaml/opam@sha256:5de979c403ddf16498f636b3887c62fb6ce66a191ecf5d64d7819eaa2a80d776
+      env:
+        HOME: /home/opam
+      options: --user 1000
+    env:
+      HOME: /home/opam
+    defaults:
+      run:
+        working-directory: /home/opam
+    steps:
+    - run: cd ~/opam-repository && (git cat-file -e bf94421703ae6d95113e5b24890f304701e47b78
+        || git fetch origin master) && git reset -q --hard bf94421703ae6d95113e5b24890f304701e47b78
+        && git log --no-decorate -n1 --oneline && opam update -u
+    - run: mkdir -p /home/opam/package
+    - name: Cloning
+      run: git clone https://github.com/$GITHUB_REPOSITORY . && git checkout $GITHUB_SHA
+      working-directory: /home/opam/package
+    - name: Pinning Packages
+      run: opam pin add -yn opam-github-workflow.dev './' && opam pin add -yn github-workflow.dev
+        './'
+      working-directory: /home/opam/package
+    - name: Installing external dependencies
+      run: opam depext -yt opam-github-workflow.dev github-workflow.dev
+      working-directory: /home/opam/package
+    - name: Installing dependencies
+      run: opam install -t -y . --deps-only
+      working-directory: /home/opam/package
+    - name: Building, installing & testing
+      run: opam exec -- dune build @install @runtest
+      working-directory: /home/opam/package
+  opensuse_15_2_leap:
+    runs-on: ubuntu-latest
+    container:
+      image: ocaml/opam@sha256:b02664ac28c726ba5da33d77253de70f19b8ff8d62b435ef35bc9fdd7762a68d
+      env:
+        HOME: /home/opam
+      options: --user 1000
+    env:
+      HOME: /home/opam
+    defaults:
+      run:
+        working-directory: /home/opam
+    steps:
+    - run: cd ~/opam-repository && (git cat-file -e bf94421703ae6d95113e5b24890f304701e47b78
+        || git fetch origin master) && git reset -q --hard bf94421703ae6d95113e5b24890f304701e47b78
+        && git log --no-decorate -n1 --oneline && opam update -u
+    - run: mkdir -p /home/opam/package
+    - name: Cloning
+      run: git clone https://github.com/$GITHUB_REPOSITORY . && git checkout $GITHUB_SHA
+      working-directory: /home/opam/package
+    - name: Pinning Packages
+      run: opam pin add -yn opam-github-workflow.dev './' && opam pin add -yn github-workflow.dev
+        './'
+      working-directory: /home/opam/package
+    - name: Installing external dependencies
+      run: opam depext -yt opam-github-workflow.dev github-workflow.dev
+      working-directory: /home/opam/package
+    - name: Installing dependencies
+      run: opam install -t -y . --deps-only
+      working-directory: /home/opam/package
+    - name: Building, installing & testing
+      run: opam exec -- dune build @install @runtest
+      working-directory: /home/opam/package
+  centos_8:
+    runs-on: ubuntu-latest
+    container:
+      image: ocaml/opam@sha256:1cdf24f875d20d0367cb7c8282487470c7728265224002a339cdbe4440fe8a60
+      env:
+        HOME: /home/opam
+      options: --user 1000
+    env:
+      HOME: /home/opam
+    defaults:
+      run:
+        working-directory: /home/opam
+    steps:
+    - run: cd ~/opam-repository && (git cat-file -e bf94421703ae6d95113e5b24890f304701e47b78
+        || git fetch origin master) && git reset -q --hard bf94421703ae6d95113e5b24890f304701e47b78
+        && git log --no-decorate -n1 --oneline && opam update -u
+    - run: mkdir -p /home/opam/package
+    - name: Cloning
+      run: git clone https://github.com/$GITHUB_REPOSITORY . && git checkout $GITHUB_SHA
+      working-directory: /home/opam/package
+    - name: Pinning Packages
+      run: opam pin add -yn opam-github-workflow.dev './' && opam pin add -yn github-workflow.dev
+        './'
+      working-directory: /home/opam/package
+    - name: Installing external dependencies
+      run: opam depext -yt opam-github-workflow.dev github-workflow.dev
+      working-directory: /home/opam/package
+    - name: Installing dependencies
+      run: opam install -t -y . --deps-only
+      working-directory: /home/opam/package
+    - name: Building, installing & testing
+      run: opam exec -- dune build @install @runtest
+      working-directory: /home/opam/package
+  fedora_32:
+    runs-on: ubuntu-latest
+    container:
+      image: ocaml/opam@sha256:086a2cbb4cd569e56c26cc1c5a8ccdb093eb7ce60275bd5a1a8efd18b6f71c27
+      env:
+        HOME: /home/opam
+      options: --user 1000
+    env:
+      HOME: /home/opam
+    defaults:
+      run:
+        working-directory: /home/opam
+    steps:
+    - run: cd ~/opam-repository && (git cat-file -e bf94421703ae6d95113e5b24890f304701e47b78
+        || git fetch origin master) && git reset -q --hard bf94421703ae6d95113e5b24890f304701e47b78
+        && git log --no-decorate -n1 --oneline && opam update -u
+    - run: mkdir -p /home/opam/package
+    - name: Cloning
+      run: git clone https://github.com/$GITHUB_REPOSITORY . && git checkout $GITHUB_SHA
+      working-directory: /home/opam/package
+    - name: Pinning Packages
+      run: opam pin add -yn opam-github-workflow.dev './' && opam pin add -yn github-workflow.dev
+        './'
+      working-directory: /home/opam/package
+    - name: Installing external dependencies
+      run: opam depext -yt opam-github-workflow.dev github-workflow.dev
+      working-directory: /home/opam/package
+    - name: Installing dependencies
+      run: opam install -t -y . --deps-only
+      working-directory: /home/opam/package
+    - name: Building, installing & testing
+      run: opam exec -- dune build @install @runtest
+      working-directory: /home/opam/package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,16 +19,12 @@ jobs:
       run: opam depext -yt opam-github-workflow.dev github-workflow.dev
     - name: Dependencies
       run: opam install -t -y . --deps-only
-    - name: Building
-      run: opam exec -- dune build
-    - name: Installing
-      run: opam exec -- dune install
-    - name: Testing
-      run: opam exec -- dune runtest
+    - name: Building, Installing and Testing
+      run: opam exec -- dune build @install @runtest
   debian_10_buster:
     runs-on: ubuntu-latest
     container:
-      image: ocaml/opam@sha256:3f9ad867a6fded20e9b0db6f23037d010a17c6fd72735689acfb6113f49f8163
+      image: ocaml/opam@sha256:4f908274fd1f29675761c0aee33a2e487b3cfb3394023458ce461339236f7d19
       env:
         HOME: /home/opam
       options: --user 1000
@@ -94,7 +90,7 @@ jobs:
   ubuntu_20_04:
     runs-on: ubuntu-latest
     container:
-      image: ocaml/opam@sha256:e907a882879515e0950cb71af419b7bc0594902041783fa2cfdd6282a81195b1
+      image: ocaml/opam@sha256:006f06a95502bdd66e07a739bb39acf5ba77276b8bc6acf8ae25bd7de5205cb7
       env:
         HOME: /home/opam
       options: --user 1000
@@ -160,7 +156,7 @@ jobs:
   opensuse_15_2_leap:
     runs-on: ubuntu-latest
     container:
-      image: ocaml/opam@sha256:b02664ac28c726ba5da33d77253de70f19b8ff8d62b435ef35bc9fdd7762a68d
+      image: ocaml/opam@sha256:8e4cdf499f8c35e3278edf02d02aa8a5c33a79d6680cdf8cbfcd0369eefcdfdd
       env:
         HOME: /home/opam
       options: --user 1000
@@ -226,7 +222,7 @@ jobs:
   fedora_32:
     runs-on: ubuntu-latest
     container:
-      image: ocaml/opam@sha256:086a2cbb4cd569e56c26cc1c5a8ccdb093eb7ce60275bd5a1a8efd18b6f71c27
+      image: ocaml/opam@sha256:896b2c51e375f84369c467f04709b7ce5329bcd6e79403d25cc97f3172b97100
       env:
         HOME: /home/opam
       options: --user 1000

--- a/README.md
+++ b/README.md
@@ -30,14 +30,13 @@ That means running this command twice may produce different results. A nice work
 (dirs :standard .github)
 
 (rule
- (with-stdout-to
-  data.out
-  (run opam github-workflow ci)))
-
-(rule
  (alias ci)
  (action
-  (diff ./.github/workflows/test.yml data.out)))
+  (progn
+   (with-stdout-to
+    data.out
+    (run opam github-workflow ci))
+   (diff? ./.github/workflows/test.yml data.out))))
 ```
 
 This allows you to run `dune build @ci` which will run the command and suggest changes to your workflow file for you. If you like the changes then you run `dune promote`. By default dune ignore files and directories that start with `.` and `_` hence the `(dirs :standard .github)`.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,40 @@ An opam plugin and library for building Github Action workflows in OCaml. For th
 
 ## Plugin Usage 
 
+We're still working out the kinks so you need to pin it!
+
 ```
 $ opam pin add --yes git+https://github.com/patricoferris/opam-github-workflow
 $ cd <my-cool-project>
 $ opam github-workflow test
 ```
+
+### OCaml-CI Behaviour 
+
+[OCaml-CI](https://github.com/ocurrent/ocaml-ci) is an OCurrent-powered CI pipeline for OCaml projects. If you can add yourself to that CI I would highly recommend it. Otherwise, you can make Github do the work for you by using the `opam github-workflow ci` command. This generates a similar workflow to what happens in OCaml-CI using docker images for the Linux distributions and the Github runners for MacOS and Windows. 
+
+The command takes a little time to run as it tries (like OCaml-CI) to be reproducible by: 
+
+  - Getting the latest *sha256* hash of the docker container 
+  - Getting the latest commit hash of the opam-repository 
+
+That means running this command twice may produce different results. A nice workflow is to add a `dune` file at the root of your project with the following contents: 
+
+```
+(dirs :standard .github)
+
+(rule
+ (with-stdout-to
+  data.out
+  (run opam github-workflow ci)))
+
+(rule
+ (alias ci)
+ (action
+  (diff ./.github/workflows/test.yml data.out)))
+```
+
+This allows you to run `dune build @ci` which will run the command and suggest changes to your workflow file for you. If you like the changes then you run `dune promote`. By default dune ignore files and directories that start with `.` and `_` hence the `(dirs :standard .github)`.
 
 ## Library Usage 
 
@@ -87,6 +116,11 @@ SYNOPSIS
 COMMANDS
        changes
            Output a git based check for changelog updates
+
+       ci  Generate a full OCaml-CI like workflow file for the latest version
+           of OCaml. This includes Debian 10 (Buster), Alpine 3.12, Ubuntu
+           20.04, Ubuntu 18.04, OpenSUSE 15.2 (Leap), CentOS 8, Fedora 32,
+           Macos and Windows
 
        test
            Output a standard opam and dune testing workflow

--- a/README.md
+++ b/README.md
@@ -105,30 +105,5 @@ jobs:
 
 ## Plugin Help 
 
-```sh
-$ opam github-workflow --help=plain
-NAME
-       opam-github-workflow - Opam Github Workflows
+See `tests/bin/run.t` for the help page of the plugin tool.
 
-SYNOPSIS
-       opam-github-workflow COMMAND ...
-
-COMMANDS
-       changes
-           Output a git based check for changelog updates
-
-       ci  Generate a full OCaml-CI like workflow file for the latest version
-           of OCaml. This includes Debian 10 (Buster), Alpine 3.12, Ubuntu
-           20.04, Ubuntu 18.04, OpenSUSE 15.2 (Leap), CentOS 8, Fedora 32,
-           Macos and Windows
-
-       test
-           Output a standard opam and dune testing workflow
-
-OPTIONS
-       --help[=FMT] (default=auto)
-           Show this help in format FMT. The value FMT must be one of `auto',
-           `pager', `groff' or `plain'. With `auto', the format is `pager` or
-           `plain' whenever the TERM env var is `dumb' or undefined.
-
-```

--- a/bin/ci.ml
+++ b/bin/ci.ml
@@ -31,7 +31,12 @@ module Docker = struct
            = Ov.string_of_arch arch)
     |> member "digest"
 
-  let peek ~arch ~tag = Os.read @@ manifest tag >|= extract_digest arch
+  let peek ~arch ~tag =
+    let env =
+      Array.concat
+        [ [| "DOCKER_CLI_EXPERIMENTAL=enabled" |]; Unix.environment () ]
+    in
+    Os.read ~env @@ manifest tag >|= extract_digest arch
 end
 
 module Platform = struct

--- a/bin/ci.ml
+++ b/bin/ci.ml
@@ -1,0 +1,155 @@
+open Lwt.Infix
+open Workflow
+open Yaml_util
+
+(* General idea from the ocurrent docker plugin https://github.com/ocurrent/ocurrent *)
+(* open Lwt.Infix *)
+
+module Dd = Dockerfile_distro
+module Ov = Ocaml_version
+
+type job = { job : Types.job }
+
+module Docker = struct
+  let mk_docker_tag distro ocv =
+    Fmt.str "ocaml/opam:%s-ocaml-%s" (Dd.tag_of_distro distro)
+      (Ov.to_string ocv)
+
+  let mk_docker_sha = Fmt.str "ocaml/opam@%s"
+
+  let manifest tag = [ "docker"; "manifest"; "inspect"; "--"; tag ]
+
+  let extract_digest arch s =
+    let open Yojson.Basic.Util in
+    let json = Yojson.Basic.from_string s in
+    member "manifests" json
+    |> to_list
+    |> List.find (fun f ->
+           member "platform" f
+           |> member "architecture"
+           |> to_string
+           = Ov.string_of_arch arch)
+    |> member "digest"
+
+  let peek ~arch ~tag = Os.read @@ manifest tag >|= extract_digest arch
+end
+
+module Platform = struct
+  let default_platforms =
+    [
+      `Debian `V10;
+      `Alpine `V3_12;
+      `Ubuntu `V20_04;
+      `Ubuntu `V18_04;
+      `OpenSUSE `V15_2;
+      `CentOS `V8;
+      `Fedora `V32;
+    ]
+end
+
+let container image =
+  container
+  |> with_image image
+  |> with_options "--user 1000"
+  |> with_container_env (simple_kv [ ("HOME", `String "/home/opam") ])
+
+let workflow ~opam_hash ~from =
+  let open Yaml_util in
+  let opam = Opam.get_opam_files () in
+  if List.length opam = 0 then failwith "No opam files found";
+  let packages = List.map (fun f -> OpamPackage.Name.to_string (fst f)) opam in
+  let packages = List.map (fun f -> f ^ ".dev") packages in
+  let joined_packages = String.concat " " packages in
+  let pinning = Opam.pin_packages packages in
+  let package = "/home/opam/package" in
+  let run_in_package = step |> with_step_workdir package in
+  let steps =
+    [
+      step |> with_step_run opam_hash;
+      step |> with_step_run ("mkdir -p " ^ package);
+      run_in_package
+      |> with_step_name "Cloning"
+      |> with_step_run
+           "git clone https://github.com/$GITHUB_REPOSITORY . && git checkout \
+            $GITHUB_SHA";
+      run_in_package
+      |> with_step_name "Pinning Packages"
+      |> with_step_run pinning;
+      run_in_package
+      |> with_step_name "Installing external dependencies"
+      |> with_step_run ("opam depext -yt " ^ joined_packages);
+      run_in_package
+      |> with_step_name "Installing dependencies"
+      |> with_step_run "opam install -t -y . --deps-only";
+      run_in_package
+      |> with_step_name "Building, installing & testing"
+      |> with_step_run "opam exec -- dune build @install @runtest";
+    ]
+  in
+  job "ubuntu-latest"
+  |> with_steps steps
+  |> with_container (container from)
+  |> with_job_env (simple_kv [ ("HOME", `String "/home/opam") ])
+  |> with_job_defaults (with_default_run (run |> with_run_workdir "/home/opam"))
+  |> fun job -> { job }
+
+let macos_and_win =
+  Test.test ~oses:[ "macos-latest"; "windows-latest" ] 1 |> snd |> fun t ->
+  ("macos_and_windows", Types.job_to_yaml t.test)
+
+let run () =
+  let yml_name s =
+    let to_underscores c s = String.(concat "_" (split_on_char c s)) in
+    let remove c s = String.(concat "" (split_on_char c s)) in
+    to_underscores '.' s
+    |> to_underscores ' '
+    |> remove '('
+    |> remove ')'
+    |> String.lowercase_ascii
+  in
+  let ocv = Ov.(Releases.latest |> with_just_major_and_minor) in
+  let get_string = function
+    | `String s -> s
+    | _ -> failwith "Expected a string"
+  in
+  let hash = Opam.reset_opam_repo () in
+  let tags =
+    Lwt_list.map_p
+      (fun d ->
+        Docker.peek ~arch:`X86_64 ~tag:(Docker.mk_docker_tag d ocv)
+        >|= fun sha -> (d, Docker.mk_docker_sha @@ get_string sha))
+      Platform.default_platforms
+  in
+  Lwt_main.run
+    ( hash >>= fun hash ->
+      tags >|= fun tags -> (hash, tags) )
+  |> fun (opam_hash, tags) ->
+  List.map
+    (fun (d, from) ->
+      ( Dd.human_readable_string_of_distro d |> yml_name,
+        workflow ~opam_hash ~from ))
+    tags
+  |> fun lst ->
+  `O
+    (macos_and_win
+    :: List.map (fun (d, job) -> (d, Types.job_to_yaml job.job)) lst)
+  |> t
+  |> with_name "OCaml-CI"
+  |> with_on (simple_event [ "push"; "pull_request" ])
+  |> Pp.workflow ~drop_null:true Fun.id Fmt.stdout
+
+(* Command line values *)
+open Cmdliner
+
+let info =
+  let doc =
+    Fmt.(
+      str
+        "Generate a full OCaml-CI like workflow file for the latest version of \
+         OCaml. This includes %a, Macos and Windows"
+        (list ~sep:comma string)
+        (List.map Dd.human_readable_string_of_distro Platform.default_platforms))
+  in
+  Term.info ~doc "ci"
+
+let cmd = (Term.(const run $ pure ()), info)

--- a/bin/ci.ml
+++ b/bin/ci.ml
@@ -152,4 +152,4 @@ let info =
   in
   Term.info ~doc "ci"
 
-let cmd = (Term.(const run $ pure ()), info)
+let cmd = (Term.(const run $ const ()), info)

--- a/bin/ci.mli
+++ b/bin/ci.mli
@@ -1,0 +1,1 @@
+val cmd : unit Cmdliner.Term.t * Cmdliner.Term.info

--- a/bin/dune
+++ b/bin/dune
@@ -2,4 +2,7 @@
  (name main)
  (public_name opam-github-workflow)
  (package opam-github-workflow)
- (libraries bos cmdliner opam-format opam-state github-workflow ocaml-version))
+ (preprocess
+  (pps ppx_deriving_yaml))
+ (libraries bos cmdliner opam-format opam-state github-workflow ocaml-version
+   lwt lwt.unix dockerfile-opam yojson))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,6 +1,6 @@
 open Cmdliner
 
-let cmds = [ Test.cmd; Changes.cmd ]
+let cmds = [ Test.cmd; Changes.cmd; Ci.cmd ]
 
 let doc = "Opam Github Workflows"
 

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -1,0 +1,37 @@
+open Lwt.Infix
+
+let opam_repo = "https://github.com/ocaml/opam-repository"
+
+let get_opam_files () =
+  let rec remove_and_read acc = function
+    | [] -> List.rev acc
+    | (Some f, g, _) :: xs ->
+        remove_and_read ((f, OpamFile.OPAM.read g) :: acc) xs
+    | (None, _, _) :: xs -> remove_and_read acc xs
+  in
+  OpamPinned.files_in_source (OpamFilename.Dir.of_string ".")
+  |> remove_and_read []
+
+let pin_packages ps =
+  let rec aux acc = function
+    | [] -> List.rev acc
+    | [ x ] -> aux (("opam pin add -yn " ^ x ^ " './'") :: acc) []
+    | x :: xs -> aux (("opam pin add -yn " ^ x ^ " './' &&") :: acc) xs
+  in
+  String.concat " " (aux [] ps)
+
+let opam_hash () =
+  Lwt_io.with_temp_dir (fun cwd ->
+      Os.exec ~cwd [ "git"; "clone"; "--depth"; "1"; opam_repo ] >>= fun () ->
+      Os.read
+        ~cwd:(Filename.concat cwd "opam-repository")
+        [ "git"; "rev-parse"; "HEAD" ])
+  >|= String.trim
+
+let reset_opam_repo () =
+  opam_hash () >|= fun hash ->
+  Fmt.str
+    "cd ~/opam-repository && (git cat-file -e %s || git fetch origin master) \
+     && git reset -q --hard %s && git log --no-decorate -n1 --oneline && opam \
+     update -u"
+    hash hash

--- a/bin/opam.mli
+++ b/bin/opam.mli
@@ -1,0 +1,5 @@
+val get_opam_files : unit -> (OpamTypes.name * OpamFile.OPAM.t) list
+
+val pin_packages : string list -> string
+
+val reset_opam_repo : unit -> string Lwt.t

--- a/bin/os.ml
+++ b/bin/os.ml
@@ -1,0 +1,24 @@
+open Lwt.Infix
+
+let exec ?cwd ?stdin ?stdout ?stderr argv =
+  Lwt_process.exec ?cwd ?stdin ?stdout ?stderr ("", Array.of_list argv)
+  >>= function
+  | Unix.WEXITED 0 -> Lwt.return_unit
+  | Unix.WEXITED n -> Lwt.fail_with (Fmt.strf "failed with exit code %i" n)
+  | _ -> Lwt.fail (Failure "Exec failed")
+
+let read ?cwd argv =
+  let r, w = Lwt_unix.pipe_in () in
+  let f r w =
+    (* FD_move closes fd *)
+    let proc = exec ?cwd ~stdout:(`FD_move w) argv in
+    let r = Lwt_io.(of_fd ~mode:input) r in
+    Lwt.finalize (fun () -> Lwt_io.read r) (fun () -> Lwt_io.close r)
+    >>= fun data ->
+    proc >>= fun () -> Lwt.return data
+  in
+  Lwt.finalize
+    (fun () ->
+      Lwt_unix.set_close_on_exec r;
+      f r w)
+    (fun () -> Lwt.return ())

--- a/bin/os.ml
+++ b/bin/os.ml
@@ -1,17 +1,17 @@
 open Lwt.Infix
 
-let exec ?cwd ?stdin ?stdout ?stderr argv =
-  Lwt_process.exec ?cwd ?stdin ?stdout ?stderr ("", Array.of_list argv)
+let exec ?cwd ?env ?stdin ?stdout ?stderr argv =
+  Lwt_process.exec ?cwd ?env ?stdin ?stdout ?stderr ("", Array.of_list argv)
   >>= function
   | Unix.WEXITED 0 -> Lwt.return_unit
   | Unix.WEXITED n -> Lwt.fail_with (Fmt.strf "failed with exit code %i" n)
   | _ -> Lwt.fail (Failure "Exec failed")
 
-let read ?cwd argv =
+let read ?cwd ?env argv =
   let r, w = Lwt_unix.pipe_in () in
   let f r w =
     (* FD_move closes fd *)
-    let proc = exec ?cwd ~stdout:(`FD_move w) argv in
+    let proc = exec ?cwd ?env ~stdout:(`FD_move w) argv in
     let r = Lwt_io.(of_fd ~mode:input) r in
     Lwt.finalize (fun () -> Lwt_io.read r) (fun () -> Lwt_io.close r)
     >>= fun data ->

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -16,13 +16,9 @@ let join s =
 
 let dune_build_install_test =
   [
-    step |> with_step_name "Building" |> with_step_run "opam exec -- dune build";
     step
-    |> with_step_name "Installing"
-    |> with_step_run "opam exec -- dune install";
-    step
-    |> with_step_name "Testing"
-    |> with_step_run "opam exec -- dune runtest";
+    |> with_step_name "Building, Installing and Testing"
+    |> with_step_run "opam exec -- dune build @install @runtest";
   ]
 
 let test ?(oses = Conf.oses) n =

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -1,12 +1,9 @@
 open Workflow
 open Cmdliner
-open Rresult.R.Infix
 
 exception NoOpamFiles
 
-type test = { test : Types.job }
-
-let test_to_yaml t : Yaml.value = `O [ ("test", Types.job_to_yaml t.test) ]
+type test = { test : Types.job } [@@deriving yaml]
 
 let join s =
   let rec aux acc = function
@@ -16,16 +13,6 @@ let join s =
     | x :: xs -> aux ((x ^ ", ") :: acc) xs
   in
   aux [] s
-
-let get_opam_files () =
-  let rec remove_and_read acc = function
-    | [] -> List.rev acc
-    | (Some f, g, _) :: xs ->
-        remove_and_read ((f, OpamFile.OPAM.read g) :: acc) xs
-    | (None, _, _) :: xs -> remove_and_read acc xs
-  in
-  OpamPinned.files_in_source (OpamFilename.Dir.of_string ".")
-  |> remove_and_read []
 
 let dune_build_install_test =
   [
@@ -38,27 +25,19 @@ let dune_build_install_test =
     |> with_step_run "opam exec -- dune runtest";
   ]
 
-let pin_packages ps =
-  let rec aux acc = function
-    | [] -> List.rev acc
-    | [ x ] -> aux (("opam pin add -yn " ^ x ^ " './'") :: acc) []
-    | x :: xs -> aux (("opam pin add -yn " ^ x ^ " './' &&") :: acc) xs
-  in
-  String.concat " " (aux [] ps)
-
-let test n =
+let test ?(oses = Conf.oses) n =
   let open Yaml_util in
-  let opam = get_opam_files () in
+  let opam = Opam.get_opam_files () in
   if List.length opam = 0 then raise NoOpamFiles;
   let packages = List.map (fun f -> OpamPackage.Name.to_string (fst f)) opam in
   let name = "Tests for " ^ join packages in
   let packages = List.map (fun f -> f ^ ".dev") packages in
   let joined_packages = String.concat " " packages in
-  let pinning = pin_packages packages in
+  let pinning = Opam.pin_packages packages in
   let matrix =
     simple_kv
       [
-        ("operating-system", list string Conf.oses);
+        ("operating-system", list string oses);
         ("ocaml-version", list string @@ Conf.ocaml_versions n);
       ]
   in
@@ -84,18 +63,13 @@ let test n =
     ]
     @ build
   in
-  let test_job =
+  ( name,
     {
       test =
         job (expr "matrix.operating-system")
         |> with_strategy (strategy |> with_matrix matrix)
         |> with_steps steps;
-    }
-  in
-  let on = simple_event [ "push"; "pull_request" ] in
-  let w : test Types.t = t test_job |> with_name name |> with_on on in
-  Pp.workflow ~drop_null:true test_to_yaml Format.str_formatter w;
-  Format.flush_str_formatter ()
+    } )
 
 let recent =
   let docv = "RECENT" in
@@ -104,55 +78,18 @@ let recent =
   in
   Arg.(value & opt int 3 & info ~doc ~docv [ "recent"; "r" ])
 
-let run recent fname stdout =
-  let pp_string s = Format.(pp_print_string std_formatter s) in
-  let open Bos.OS in
+let run recent =
   try
-    let output = test recent in
-    let res =
-      if stdout then (
-        pp_string output;
-        Ok false)
-      else
-        Dir.create (Fpath.v Conf.output_dir) >>= fun _ ->
-        let output_path = Fpath.((v Conf.output_dir / fname) + "yml") in
-        File.exists output_path >>= fun b ->
-        if b then (
-          pp_string "File already exists, doing nothing";
-          Ok false)
-        else
-          match File.write output_path output with
-          | Ok _ -> Ok true
-          | Error (`Msg m) ->
-              pp_string m;
-              Ok false
-    in
-    match res with
-    | Ok b ->
-        if b then
-          pp_string
-            ("Successfully created test workflow in "
-            ^ Fpath.(to_string (v Conf.output_dir)))
-    | Error (`Msg m) -> pp_string m
+    let name, test_job = test recent in
+    let on = simple_event [ "push"; "pull_request" ] in
+    let w : test Types.t = t test_job |> with_name name |> with_on on in
+    Pp.workflow ~drop_null:true test_to_yaml Format.std_formatter w
   with NoOpamFiles ->
     Format.pp_print_string Format.std_formatter
       "No Opam files found in the current directory"
-
-let fname =
-  let docv = "FNAME" in
-  let doc = "The name of the file the test workflow will go to e.g. `test' " in
-  Arg.(value & opt string "test" & info ~doc ~docv [ "fname"; "f" ])
-
-let stdout =
-  let docv = "STDOUT" in
-  let doc =
-    "With this flag set, the workflow will go to standard out rather than \
-     making the file"
-  in
-  Arg.(value & flag & info ~doc ~docv [ "s"; "stdout" ])
 
 let info =
   let doc = "Output a standard opam and dune testing workflow" in
   Term.info ~doc "test"
 
-let cmd = (Term.(const run $ recent $ fname $ stdout), info)
+let cmd = (Term.(const run $ recent), info)

--- a/bin/test.mli
+++ b/bin/test.mli
@@ -1,1 +1,9 @@
+open Workflow
+
+type test = { test : Types.job } [@@deriving yaml]
+
 val cmd : unit Cmdliner.Term.t * Cmdliner.Term.info
+
+val test : ?oses:string list -> int -> string * test
+(** [test oses n] creates a standard testing workflow using Github runners for
+    the [n] most recent versions of OCaml on [oses] platforms *)

--- a/dune
+++ b/dune
@@ -1,6 +1,3 @@
-(mdx
- (files README.md))
-
 (dirs :standard .github)
 
 (rule

--- a/dune
+++ b/dune
@@ -1,11 +1,10 @@
 (dirs :standard .github)
 
 (rule
- (with-stdout-to
-  data.out
-  (run opam github-workflow ci)))
-
-(rule
  (alias ci)
  (action
-  (diff ./.github/workflows/test.yml data.out)))
+  (progn
+   (with-stdout-to
+    data.out
+    (run opam github-workflow ci))
+   (diff? ./.github/workflows/test.yml data.out))))

--- a/dune
+++ b/dune
@@ -1,2 +1,14 @@
 (mdx
  (files README.md))
+
+(dirs :standard .github)
+
+(rule
+ (with-stdout-to
+  data.out
+  (run opam github-workflow ci)))
+
+(rule
+ (alias ci)
+ (action
+  (diff ./.github/workflows/test.yml data.out)))

--- a/dune-project
+++ b/dune-project
@@ -1,26 +1,21 @@
 (lang dune 2.7)
-
 (cram enable)
-
 (name github-workflow)
-
 (generate_opam_files true)
-
-(source
- (github patricoferris/opam-github-workflow))
-
+(source (github patricoferris/opam-github-workflow))
 (license ISC)
-
 (authors "Patrick Ferris")
-
 (maintainers "pf341@patricoferris.com")
-
 (package
  (name opam-github-workflow)
  (synopsis "Plugin to add standard Github Action workflows")
  (description
-   "This opam plugin allows you to generate standard github workflows for things like checking changelogs and running tests")
+  "This opam plugin allows you to generate standard github workflows for things like checking changelogs and running tests")
  (depends
+  (yojson (>= 1.7.0))
+  (ppx_deriving_yaml (>= 0.1.0))
+  (lwt (>= 5.4.0))
+  (dockerfile-opam (>= 7.0.0))
   bos
   cmdliner
   opam-format
@@ -29,14 +24,9 @@
   ocaml-version
   (alcotest :with-test)
   (mdx :with-test)))
-
 (package
  (name github-workflow)
  (synopsis "Build Github Workflows in OCaml")
  (description "A library for building Github Action workflows")
- (depends
-  yaml
-  ppx_deriving_yaml
-  (alcotest :with-test)))
-
+ (depends yaml ppx_deriving_yaml (alcotest :with-test)))
 (using mdx 0.1)

--- a/opam-github-workflow.opam
+++ b/opam-github-workflow.opam
@@ -10,6 +10,10 @@ homepage: "https://github.com/patricoferris/opam-github-workflow"
 bug-reports: "https://github.com/patricoferris/opam-github-workflow/issues"
 depends: [
   "dune" {>= "2.7"}
+  "yojson" {>= "1.7.0"}
+  "ppx_deriving_yaml" {>= "0.1.0"}
+  "lwt" {>= "5.4.0"}
+  "dockerfile-opam" {>= "7.0.0"}
   "bos"
   "cmdliner"
   "opam-format"

--- a/tests/bin/run.t
+++ b/tests/bin/run.t
@@ -1,43 +1,12 @@
 Building a test workflow with no opam file prints error
 
   $ opam github-workflow test
-  No Opam files found in the current directory
+  Fatal error: exception Dune__exe__Test.NoOpamFiles
+  [2]
 
 Source a project and try building a test workflow
 
   $ opam source yaml > /dev/null && cd yaml.2.1.0 && opam github-workflow test 
-  Successfully created test workflow in ./.github/workflows
-  $ cat .github/workflows/test.yml
-  name: Tests for yaml
-  on: [push, pull_request]
-  jobs:
-    test:
-      strategy:
-        matrix:
-          operating-system: [macos-latest, ubuntu-latest, windows-latest]
-          ocaml-version: [4.11.1, 4.10.2, 4.09.1]
-      runs-on: ${{ matrix.operating-system }}
-      steps:
-      - uses: actions/checkout@v2
-      - uses: avsm/setup-ocaml@v1
-        with:
-          ocaml-version: ${{ matrix.ocaml-version }}
-      - name: Pinning Package
-        run: opam pin add -yn yaml.dev './'
-      - name: Packages
-        run: opam depext -yt yaml.dev
-      - name: Dependencies
-        run: opam install -t -y . --deps-only
-      - name: Building
-        run: opam exec -- dune build
-      - name: Installing
-        run: opam exec -- dune install
-      - name: Testing
-        run: opam exec -- dune runtest
-
-Passing stdout should print the workflow to standard out 
-
-  $ opam github-workflow test --stdout
   name: Tests for yaml
   on: [push, pull_request]
   jobs:
@@ -67,7 +36,7 @@ Passing stdout should print the workflow to standard out
 
 Using a different number of 'recent version'
 
-  $ opam github-workflow test --recent=5 --stdout
+  $ opam github-workflow test --recent=5
   name: Tests for yaml
   on: [push, pull_request]
   jobs:

--- a/tests/bin/run.t
+++ b/tests/bin/run.t
@@ -63,3 +63,31 @@ Using a different number of 'recent version'
         run: opam exec -- dune install
       - name: Testing
         run: opam exec -- dune runtest
+
+Help page of the plugin 
+
+  $ opam github-workflow --help=plain
+  NAME
+         opam-github-workflow - Opam Github Workflows
+  
+  SYNOPSIS
+         opam-github-workflow COMMAND ...
+  
+  COMMANDS
+         changes
+             Output a git based check for changelog updates
+  
+         ci  Generate a full OCaml-CI like workflow file for the latest version
+             of OCaml. This includes Debian 10 (Buster), Alpine 3.12, Ubuntu
+             20.04, Ubuntu 18.04, OpenSUSE 15.2 (Leap), CentOS 8, Fedora 32,
+             Macos and Windows
+  
+         test
+             Output a standard opam and dune testing workflow
+  
+  OPTIONS
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of `auto',
+             `pager', `groff' or `plain'. With `auto', the format is `pager` or
+             `plain' whenever the TERM env var is `dumb' or undefined.
+  

--- a/tests/bin/run.t
+++ b/tests/bin/run.t
@@ -27,12 +27,8 @@ Source a project and try building a test workflow
         run: opam depext -yt yaml.dev
       - name: Dependencies
         run: opam install -t -y . --deps-only
-      - name: Building
-        run: opam exec -- dune build
-      - name: Installing
-        run: opam exec -- dune install
-      - name: Testing
-        run: opam exec -- dune runtest
+      - name: Building, Installing and Testing
+        run: opam exec -- dune build @install @runtest
 
 Using a different number of 'recent version'
 
@@ -57,12 +53,8 @@ Using a different number of 'recent version'
         run: opam depext -yt yaml.dev
       - name: Dependencies
         run: opam install -t -y . --deps-only
-      - name: Building
-        run: opam exec -- dune build
-      - name: Installing
-        run: opam exec -- dune install
-      - name: Testing
-        run: opam exec -- dune runtest
+      - name: Building, Installing and Testing
+        run: opam exec -- dune build @install @runtest
 
 Help page of the plugin 
 


### PR DESCRIPTION
This PR:

 - Adds `opam github-workflow ci` a command that generates an `ocaml-ci` like Github workflow that uses docker containers for linux distros and github runners for windows and macos. It requires "docker" and "git" to be installed because it needs to query to get digests/hashes. 